### PR TITLE
Hide Strossle V1 widget on small screens < 1200px

### DIFF
--- a/webpack/src/universitas/components/Story/StoryFoot.js
+++ b/webpack/src/universitas/components/Story/StoryFoot.js
@@ -1,6 +1,6 @@
 import { reverse, toStory } from 'universitas/ducks/router'
 import RelatedStories from 'universitas/components/RelatedStory'
-import StrossleWidget from 'universitas/components/StrossleWidget'
+import Strossle from 'universitas/components/Strossle'
 import FacebookComments from 'universitas/components/FacebookComments'
 
 const STROSSLE_ID = 'dff15dfe-e8ca-4e6d-b547-8038ab88562b'
@@ -23,8 +23,8 @@ const StoryFoot = ({
       {comment_field == 'facebook' && <FacebookComments url={url} />}
       {strossle_enabled ? (
         <>
-          <StrossleWidget v2 url={url} id={STROSSLE_ID} />
-          <StrossleWidget v1 url={url} id={ACCELERATOR_ID} />
+          <Strossle v2 url={url} id={STROSSLE_ID} />
+          <Strossle v1 url={url} id={ACCELERATOR_ID} />
         </>
       ) : (
         <RelatedStories related_stories={related_stories} />

--- a/webpack/src/universitas/components/Strossle/Strossle.js
+++ b/webpack/src/universitas/components/Strossle/Strossle.js
@@ -1,5 +1,5 @@
 const StrossleV1 = ({ id, url }) => (
-  <div data-spklw-widget={id} data-spklw-url={url} />
+  <div className="StrossleV1" data-spklw-widget={id} data-spklw-url={url} />
 )
 
 const StrossleV2 = ({ id, url }) => {

--- a/webpack/src/universitas/components/Strossle/Strossle.scss
+++ b/webpack/src/universitas/components/Strossle/Strossle.scss
@@ -1,0 +1,8 @@
+@import 'universitas/styles/_common.scss';
+
+// Strossle widget V1 breaks layout on small screens
+.StrossleV1 {
+  @media (max-width: $content-width) {
+    display: none;
+  }
+}

--- a/webpack/src/universitas/components/Strossle/Strossle.test.js
+++ b/webpack/src/universitas/components/Strossle/Strossle.test.js
@@ -1,0 +1,10 @@
+import Strossle from './index'
+import renderer from 'react-test-renderer'
+
+describe('Strossle', () => {
+  test('renders correctly', () => {
+    const tree = renderer.create(<Strossle />).toJSON()
+    expect(tree).toEqual(expect.any(Object))
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/webpack/src/universitas/components/Strossle/__snapshots__/Strossle.test.js.snap
+++ b/webpack/src/universitas/components/Strossle/__snapshots__/Strossle.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Strossle renders correctly 1`] = `
+<div
+  className="strossle-widget-undefined"
+/>
+`;

--- a/webpack/src/universitas/components/Strossle/index.js
+++ b/webpack/src/universitas/components/Strossle/index.js
@@ -1,0 +1,3 @@
+import Strossle from './Strossle.js'
+import './Strossle.scss'
+export default Strossle


### PR DESCRIPTION
The "Accelerator" Strossle Widget breaks the layout in stories on phones and other small screens.

This CSS change will hide the widget on small screens