### PR TITLE
better pg search for contributors and photo

### DIFF
--- a/django/api/contributors.py
+++ b/django/api/contributors.py
@@ -1,12 +1,12 @@
 import logging
 
 from django.db.models import Prefetch
-from rest_framework import serializers, viewsets
-from url_filter.integrations.drf import DjangoFilterBackend
 
 from apps.contributors import tasks
 from apps.contributors.models import Contributor, Position, Stint
 from apps.photo.models import ImageFile
+from rest_framework import serializers, viewsets
+from url_filter.integrations.drf import DjangoFilterBackend
 from utils.serializers import AbsoluteURLField, PhoneNumberField
 
 logger = logging.getLogger(__name__)
@@ -127,12 +127,10 @@ class ContributorViewSet(viewsets.ModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filter_fields = ['id', 'status', 'display_name', 'byline_photo']
 
-    def get_queryset(self):
-        """
-        use fancy postgresql trigram unaccent search
-        """
+    def filter_queryset(self, queryset):
+        """Use fancy postgresql trigram unaccent search """
         query = self.request.query_params.get('search')
+        queryset = super().filter_queryset(queryset)
         if query is not None:
-            return self.queryset.search(query)
-
-        return self.queryset
+            return queryset.search(query)
+        return queryset

--- a/django/apps/contributors/models.py
+++ b/django/apps/contributors/models.py
@@ -12,8 +12,9 @@ from django.db import models
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
-from model_utils.models import TimeStampedModel
 
+from model_utils.models import TimeStampedModel
+from utils.dbfuncs import TrigramWordSimilarity
 from utils.decorators import cache_memoize
 
 from .fuzzy_name_search import FuzzyNameSearchMixin
@@ -49,7 +50,7 @@ class ContributorQuerySet(models.QuerySet):
 
     def search(self, query, cutoff=0.5):
         """fuzzy name search"""
-        trigram = TrigramSimilarity('display_name', query)
+        trigram = TrigramWordSimilarity('display_name', query)
         queryset = self.annotate(similarity=trigram).order_by('-similarity')
         result = queryset.filter(similarity__gt=cutoff)
         if not result:

--- a/django/apps/photo/models.py
+++ b/django/apps/photo/models.py
@@ -7,7 +7,6 @@ import re
 from statistics import median
 
 from django.contrib.postgres.fields import JSONField
-from django.contrib.postgres.search import TrigramSimilarity
 from django.core.files.storage import default_storage
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import FileExtensionValidator
@@ -16,13 +15,14 @@ from django.db.models.expressions import RawSQL
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
-from model_utils.models import TimeStampedModel
-from slugify import Slugify
-from sorl.thumbnail import ImageField
 
 # from apps.issues.models import current_issue
 from apps.contributors.models import Contributor
 from apps.photo import file_operations
+from model_utils.models import TimeStampedModel
+from slugify import Slugify
+from sorl.thumbnail import ImageField
+from utils.dbfuncs import TrigramWordSimilarity
 from utils.merge_model_objects import merge_instances
 from utils.model_mixins import EditURLMixin
 
@@ -157,7 +157,7 @@ class ImageFileManager(models.Manager):
             return qs.filter(pk__in=pks)
 
         if filename:
-            trigram = TrigramSimilarity('stem', Path(filename).stem)
+            trigram = TrigramWordSimilarity('stem', Path(filename).stem)
             return qs.annotate(
                 similarity=trigram,
             ).filter(

--- a/django/apps/stories/models/search_mixin.py
+++ b/django/apps/stories/models/search_mixin.py
@@ -4,15 +4,12 @@ from django.contrib.postgres.search import (
     SearchRank,
     SearchVector,
     SearchVectorField,
-    TrigramSimilarity,
 )
 from django.db.models import (
     Case,
-    CharField,
     ExpressionWrapper,
     F,
     FloatField,
-    Func,
     Model,
     QuerySet,
     Value,
@@ -21,46 +18,7 @@ from django.db.models import (
 from django.db.models.functions import Concat
 from django.utils.timezone import now
 
-
-class TrigramWordSimilarity(Func):
-    output_field = FloatField()
-    function = 'WORD_SIMILARITY'
-
-    def __init__(self, expression, string, **extra):
-        if not hasattr(string, 'resolve_expression'):
-            string = Value(string)
-        super().__init__(string, expression, **extra)
-
-
-class LogAge(Func):
-    """Calculate log 2 of days since datetime column"""
-    # Minimum age 1 day. Prevent log of zero error and unintended large
-    # effect of log of very small inputs.
-    output_field = FloatField()
-
-    template = (
-        f'greatest(1.0, log(2::numeric, ('
-        'abs(extract(epoch FROM (TIMESTAMP '
-        "'%(when)s' - "
-        'COALESCE(%(table)s.%(timefield)s,%(table)s.created)'
-        '))) / (60 * 60 * 24))::numeric'
-        '))'
-    )
-
-    # greatest(1.0, log(2, number))
-    # return at least 1.0 to avoid zero division or very skewed results
-    # for logs close to zero
-
-    # abs(extract(epoch FROM (when - then)))
-    # Extract total seconds in timedelta `now - then`
-    # `epoch` = 1970-01-01 = unix epoch = total seconds
-
-    # / (60 * 60 * 24)
-    # Divide by minutes and seconds and hours: seconds -> days
-
-    # ::numeric
-    #  Cast result as `numeric` using PostgreSQL type cast notation
-    # `numeric` = decimal type
+from utils.dbfuncs import LogAge, TrigramWordSimilarity
 
 
 class FullTextSearchQuerySet(QuerySet):

--- a/django/utils/dbfuncs.py
+++ b/django/utils/dbfuncs.py
@@ -1,0 +1,42 @@
+from django.db.models import FloatField, Func, Value
+
+
+class TrigramWordSimilarity(Func):
+    output_field = FloatField()
+    function = 'WORD_SIMILARITY'
+
+    def __init__(self, expression, string, **extra):
+        if not hasattr(string, 'resolve_expression'):
+            string = Value(string)
+        super().__init__(string, expression, **extra)
+
+
+class LogAge(Func):
+    """Calculate log 2 of days since datetime column"""
+    # Minimum age 1 day. Prevent log of zero error and unintended large
+    # effect of log of very small inputs.
+    output_field = FloatField()
+
+    template = (
+        f'greatest(1.0, log(2::numeric, ('
+        'abs(extract(epoch FROM (TIMESTAMP '
+        "'%(when)s' - "
+        'COALESCE(%(table)s.%(timefield)s,%(table)s.created)'
+        '))) / (60 * 60 * 24))::numeric'
+        '))'
+    )
+
+    # greatest(1.0, log(2, number))
+    # return at least 1.0 to avoid zero division or very skewed results
+    # for logs close to zero
+
+    # abs(extract(epoch FROM (when - then)))
+    # Extract total seconds in timedelta `now - then`
+    # `epoch` = 1970-01-01 = unix epoch = total seconds
+
+    # / (60 * 60 * 24)
+    # Divide by minutes and seconds and hours: seconds -> days
+
+    # ::numeric
+    #  Cast result as `numeric` using PostgreSQL type cast notation
+    # `numeric` = decimal type


### PR DESCRIPTION
Reuse TrigramWordSearch for contributor and photo api endpoints.

This will also match partial fuzzy word matches in the prodsys filtering field.

Also change order of filtering in contributor search function. Makes "search" happen as the final filter, instead of the first filter. 