### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/django/apps/contributors/fuzzy_name_search.py
+++ b/django/apps/contributors/fuzzy_name_search.py
@@ -6,7 +6,7 @@ import re
 
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from slugify import Slugify
 
 logger = logging.getLogger(__name__)
@@ -72,8 +72,8 @@ class FuzzyNameSearchMixin:
             MINIMUM_RATIO = 85
             candidates = []
             for contributor in base_query.all():
-                ratio = fuzz.ratio(contributor.display_name, full_name)
-                if ratio >= MINIMUM_RATIO:
+                ratio = fuzz.ratio(contributor.display_name, full_name, score_cutoff=MINIMUM_RATIO)
+                if ratio:
                     # TODO: two contributors with same name.
                     return contributor
                 if contributor.display_name in full_name:

--- a/django/notebooks/commit/Merge duplicates 1.15.ipynb
+++ b/django/notebooks/commit/Merge duplicates 1.15.ipynb
@@ -9,7 +9,7 @@
     "import logging\n",
     "from django.db import models\n",
     "from utils.merge_model_objects import merge_instances\n",
-    "from fuzzywuzzy import fuzz\n",
+    "from rapidfuzz import fuzz\n",
     "from tqdm import tqdm\n",
     "from collections import Counter"
    ]

--- a/django/requirements.in
+++ b/django/requirements.in
@@ -43,8 +43,7 @@ beautifulsoup4
 pypdf2
 requests
 requests-html
-fuzzywuzzy
-python-Levenshtein
+rapidfuzz
 diff-match-patch
 awesome-slugify
 faker

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -51,7 +51,6 @@ fake-useragent==0.1.11    # via requests-html
 faker==2.0.2
 flower==0.9.3
 ftfy==5.6
-fuzzywuzzy==0.17.0
 hiredis==1.0.0
 idna==2.8                 # via requests
 imagehash==4.0
@@ -96,10 +95,10 @@ pytest-forked==1.0.2      # via pytest-xdist
 pytest-xdist==1.29.0
 pytest==5.2.0
 python-dateutil==2.8.0    # via botocore, faker
-python-levenshtein==0.12.0
 python3-openid==3.1.0     # via django-allauth
 pytz==2019.2              # via babel, celery, django, flower
 pywavelets==1.0.3         # via imagehash
+rapidfuzz==0.3.0
 redis==3.3.8
 regex==2019.8.19          # via awesome-slugify
 requests-html==0.10.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy

Apparently I did something wrong somewhere since it does not install rapidfuzz in travis